### PR TITLE
feat: add next branch to build matrix

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -40,6 +40,12 @@ jobs:
             sphinx: "8.2.3"
             mermaid: "1.0.0"
             jinja: "3.1.1"
+          - version: "next"
+            source: "heads"
+            python: "3.12"
+            sphinx: "8.2.3"
+            mermaid: "1.0.0"
+            jinja: "3.1.1"
     steps:
       - name: 🧾 Log event & matrix, determine slug
         run: |


### PR DESCRIPTION
This PR should allow the `next` branch to be displayed in the version selector on docs.octoprint.org, which would be quite helpful for development purposes.